### PR TITLE
Fix GitHub Pages deploy

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -7,6 +7,8 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4


### PR DESCRIPTION
## Summary
- allow GitHub Actions to push to the `gh-pages` branch

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6842ff36ec1c832894ffb9a8bb0384aa