### PR TITLE
Fix GitHub Pages base path

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,3 +17,5 @@ An identicon favicon is embedded via a data URI in `index.html`. Replace it with
 
 The project is deployed using GitHub Actions to the `gh-pages` branch. Any push to `master` builds the Vue app and publishes the `dist` folder.
 
+Vite's `base` option is configured to `/pondpilot-demo/` in `vite.config.js` so that asset paths resolve correctly when the site is hosted at `https://smolevich.github.io/pondpilot-demo/`.
+

--- a/vite.config.js
+++ b/vite.config.js
@@ -3,5 +3,6 @@ import vue from '@vitejs/plugin-vue'
 
 // https://vite.dev/config/
 export default defineConfig({
+  base: '/pondpilot-demo/',
   plugins: [vue()],
 })


### PR DESCRIPTION
## Summary
- set `base` in `vite.config.js` to `/pondpilot-demo/`
- document Vite base path in README

## Testing
- `npm ci`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_684300b44fc48328ba2cc5f033c9f654