### PR TITLE
Switch to bundled pondpilot widget

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,7 +5,6 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>PondPilot Demo</title>
     <link rel="icon" href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAGQAAABkCAIAAAD/gAIDAAABF0lEQVR4nO3csQ3CQBAAQZ4+IYUanEMNxDRqatj/wEKeyU+WVhedXh631+My67t9pmfv7+ffffc6PXlCYgViBWIFYgViBWIFYgViBWIFYgViBWIFYgViBWIFYgViBWIFY9/36eGVe/ZRVu73NisQKxArECsQKxArECsQKxArECsQKxArECsQKxArECsQKxArECtYusGvOOod/AqbFYgViBWIFYgViBWIFYgViBWIFYgViBWIFYgViBWIFYgViBWIFXgHH9isQKxArECsQKxArECsQKxArECsQKxArECsQKxArECsQKxArECsYKz8D/5sbFYgViBWIFYgViBWIFYgViBWIFYgViBWIFYgViBWIFYgViBWIFbwA+VkG01G9unVAAAAAElFTkSuQmCC" />
-    <script src="https://cdn.jsdelivr.net/gh/pondpilot/pondpilot-widget@latest/dist/pondpilot-widget.min.js"></script>
   </head>
   <body>
     <div id="app"></div>

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "pondpilot-demo",
       "version": "0.0.0",
       "dependencies": {
+        "pondpilot-widget": "^1.0.2",
         "vue": "^3.5.13",
         "xlsx": "^0.18.5"
       },
@@ -1085,6 +1086,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/pondpilot-widget": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/pondpilot-widget/-/pondpilot-widget-1.0.2.tgz",
+      "integrity": "sha512-ejiI+z0e13p4MlG5Qs8qQsSltIsYSADD6pDoy8A7s1wpnQjmM8Xuc6yupQ3rUsVmiE8r3U3Th9YGQT+DhCoEVw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0",
+        "npm": ">=6.0.0"
       }
     },
     "node_modules/postcss": {

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
+    "pondpilot-widget": "^1.0.2",
     "vue": "^3.5.13",
     "xlsx": "^0.18.5"
   },

--- a/src/main.js
+++ b/src/main.js
@@ -1,4 +1,5 @@
 import { createApp } from 'vue'
+import 'pondpilot-widget'
 import './style.css'
 import App from './App.vue'
 


### PR DESCRIPTION
## Summary
- use `pondpilot-widget` package instead of CDN
- import the widget in the Vue entry

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68442296af1c83288c46791ad83b7ddc