### PR TITLE
Improve PondPilot demo interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 This demo showcases using [pondpilot-widget](https://github.com/pondpilot/pondpilot-widget) inside a Vue 3 application. It allows you to upload large CSV or Excel files and query them locally in your browser via DuckDB WASM.
 
+On the page, upload a file and a SQL editor will appear. The data is loaded into a table named `data`. Edit the query and run it to explore your file directly in the browser.
+
 ## Setup
 
 ```bash

--- a/src/App.vue
+++ b/src/App.vue
@@ -4,6 +4,9 @@ import FileLoader from './components/FileLoader.vue'
 
 <template>
   <h1>PondPilot Demo</h1>
+  <p>Upload a CSV or Excel file to create a <code>data</code> table. Edit the
+  query in the editor and click the run button (or press <kbd>Shift</kbd>+<kbd>Enter</kbd>)
+  to see the results.</p>
   <FileLoader />
 </template>
 

--- a/src/components/FileLoader.vue
+++ b/src/components/FileLoader.vue
@@ -38,6 +38,7 @@ async function handleFile(event) {
   }
 
   widget.editor.querySelector('pre').textContent = 'SELECT * FROM data LIMIT 20;'
+  await widget.run()
 }
 </script>
 


### PR DESCRIPTION
## Summary
- automatically run query after loading data file
- add usage instructions to README and on page

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68445289c20c8328abd12da4073f1c13